### PR TITLE
Copy BearerToken from kubeConfig

### DIFF
--- a/sources/kube_factory.go
+++ b/sources/kube_factory.go
@@ -172,6 +172,7 @@ func CreateKubeSources(uri *url.URL, c cache.Cache) ([]api.Source, error) {
 		Port:            uint(kubeletPort),
 		EnableHttps:     kubeletHttps,
 		TLSClientConfig: kubeConfig.TLSClientConfig,
+		BearerToken:     kubeConfig.BearerToken,
 	}
 
 	kubeletApi, err := datasource.NewKubelet(kubeletConfig)


### PR DESCRIPTION
This is the only other change required for these to work (at least my unit test sees the bearer token, but the test its not included in this PR)
